### PR TITLE
Fixing params encoding issue

### DIFF
--- a/packages/features/src/request.ts
+++ b/packages/features/src/request.ts
@@ -13,7 +13,7 @@ export default async function request(
   for (const key in params) {
     searchParams.append(
       key,
-      encodeURIComponent(params[key].toString())
+      params[key].toString()
     );
   }
 

--- a/packages/features/test/unit/index.test.ts
+++ b/packages/features/test/unit/index.test.ts
@@ -40,7 +40,7 @@ test('getCollection() should return a collection', async function() {
 
 test('getFeatures() should fetch features with parameters', async function() {
   mockRequest(
-    'https://service.com/collections/test/items?f=json&bbox=1%252C2%252C3%252C4&bbox_crs=test&limit=1',
+    'https://service.com/collections/test/items?f=json&bbox=1%2C2%2C3%2C4&bbox_crs=test&limit=1',
     {
       type: 'FeatureCollection',
       features: [],

--- a/packages/features/test/unit/request.test.ts
+++ b/packages/features/test/unit/request.test.ts
@@ -33,3 +33,14 @@ test('request() should accept additional parameters', async () => {
   });
   expect(result.success).toBe(true);
 });
+
+test('request() should accept date formatted parameter', async () => {
+  mockRequest('https://www.example.com?f=json&datetime=2014-01-01T00%3A00%3A00.000Z%2F2014-01-02T00%3A00%3A00.000Z', {
+    success: true,
+  });
+
+  const result = await request('https://www.example.com', {
+    datetime: '2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z',
+  });
+  expect(result.success).toBe(true);
+});


### PR DESCRIPTION
I'm using ogcapi-js/features with the reference implementation of the OCG standard ([pygeoapi](https://github.com/geopython/pygeoapi)) but I get error 400 as soon as I start passing `datetime` parameters:

```
[2021-03-17T09:31:34Z] {/var/folders/gc/ry76n9m15l7br5j9tnqvy5kc0000gn/T/tmp1Yp0gu/lib/python3.7/site-packages/pygeoapi/api.py:813} ERROR - {'code': 'InvalidParameterValue', 'description': 'Unknown string format: 2014-01-01T00%3A00%3A00.000Z%2F2014-01-02T00%3A00%3A00.000Z'}
```

I think that the issue came from a wrong use of `encodeURIComponent` at https://github.com/haoliangyu/ogcapi-js/blob/7550268f903a6ddc47eb0fb5bb2ca476605bbd8f/packages/features/src/request.ts#L16

As you are using a `URLSearchParams` you are already encoding the parameter:

```javascript
searchParams = new URLSearchParams();
searchParams.append('datetime', '2014-01-01T00:00:00.000Z')
searchParams.toString()
'datetime=2014-01-01T00%3A00%3A00.000Z'
```

By calling another `encodeURIComponent` the final parameter is encoded twice.
