### PR TITLE
Add support for the `properties` query parameter

### DIFF
--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -277,7 +277,7 @@ export interface IGetFeaturesOptions extends IRequestOptions {
   /**
    * properties to include for the requested features.
    */
-  properties?: string[];
+  properties?: string[] | string;
 }
 
 /**

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -1,5 +1,6 @@
 import { stringifyBbox } from './bbox';
 import { stringifyDatetime, IDateRange  } from './datetime';
+import { stringifyProperties } from './properties';
 import request, { IRequestParams } from './request';
 import { FeatureCollection, Feature } from 'geojson';
 
@@ -74,6 +75,10 @@ export class Service {
       if (options.bboxCrs) {
         requestParams['bbox_crs'] = options.bboxCrs;
       }
+    }
+
+    if (options.properties) {
+      requestParams.properties = stringifyProperties(options.properties);
     }
 
     if (options.datetime) {
@@ -268,6 +273,11 @@ export interface IGetFeaturesOptions extends IRequestOptions {
    * return CRS for the requested features
    */
   crs?: string;
+
+  /**
+   * properties to include for the requested features.
+   */
+  properties?: string[];
 }
 
 /**

--- a/packages/features/src/properties.ts
+++ b/packages/features/src/properties.ts
@@ -1,0 +1,20 @@
+export function isValidProperties(properties: string[] | string): boolean {
+  if (!Array.isArray(properties) && typeof properties !== 'string') {
+    return false;
+  }
+
+  // at least one property should be defined
+  if (properties.length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+export function stringifyProperties(properties: string[] | string): string {
+  if (!isValidProperties(properties)) {
+    throw new Error('invalid properties');
+  }
+
+  return properties.toString();
+}

--- a/packages/features/test/unit/properties.test.ts
+++ b/packages/features/test/unit/properties.test.ts
@@ -1,0 +1,26 @@
+import { isValidProperties, stringifyProperties } from '../../src/properties';
+
+test('isValidProperties() should return true for valid input', () => {
+  expect(isValidProperties('PROPERTY_A')).toBe(true);
+  expect(isValidProperties(['PROPERTY_A', 'PROPERTY_B'])).toBe(true);
+});
+
+
+test('isValidProperties() should return false for invalid input', () => {
+  expect(isValidProperties('')).toBe(false);
+  expect(isValidProperties([])).toBe(false);
+  expect(isValidProperties(1 as any)).toBe(false);
+  expect(isValidProperties({} as any)).toBe(false);
+});
+
+test('stringifyProperties() should throw an error for valid input', () => {
+  expect(() => stringifyProperties([])).toThrow('invalid properties');
+});
+
+test('isValidProperties() should return the passed string for string input', () => {
+  expect(stringifyProperties('PROPERTY_A')).toBe('PROPERTY_A');
+});
+
+test('isValidProperties() should return a comma seperated properties string for array input', () => {
+  expect(stringifyProperties(['PROPERTY_A', 'PROPERTY_B'])).toBe('PROPERTY_A,PROPERTY_B');
+});


### PR DESCRIPTION
This PR adds support for the `properties` query parameter as specified in https://github.com/haoliangyu/ogcapi-js/issues/15#issuecomment-988658224.

This allows users to control which properties are returned when features are requested.