### PR TITLE
Add support for the `sortby` query parameter

### DIFF
--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -5,6 +5,10 @@ import { stringifySortBy, TSortBy } from './sortby';
 import request, { IRequestParams } from './request';
 import { FeatureCollection, Feature } from 'geojson';
 
+// re-export types and interfaces for better user compatibility
+export { IDateRange } from './datetime';
+export { TSortBy, ISortByItem } from './sortby';
+
 /**
  * configuration for a OGC Features API service
  */

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -1,6 +1,7 @@
 import { stringifyBbox } from './bbox';
 import { stringifyDatetime, IDateRange  } from './datetime';
 import { stringifyProperties } from './properties';
+import { stringifySortBy, TSortBy } from './sortby';
 import request, { IRequestParams } from './request';
 import { FeatureCollection, Feature } from 'geojson';
 
@@ -75,6 +76,10 @@ export class Service {
       if (options.bboxCrs) {
         requestParams['bbox_crs'] = options.bboxCrs;
       }
+    }
+
+    if (options.sortby) {
+      requestParams.sortBy = stringifySortBy(options.sortby);
     }
 
     if (options.properties) {
@@ -278,6 +283,11 @@ export interface IGetFeaturesOptions extends IRequestOptions {
    * properties to include for the requested features
    */
   properties?: string | string[];
+
+  /**
+   * sorting direction in which features should be returned
+   */
+   sortby?: TSortBy;
 }
 
 /**

--- a/packages/features/src/sortby.ts
+++ b/packages/features/src/sortby.ts
@@ -1,0 +1,93 @@
+/**
+ * sort item descriptor
+ */
+ export interface ISortByItem {
+  /**
+   * property to sort by
+   */
+  property: string;
+
+  /**
+   * sort order
+   *
+   * @default asc
+   */
+  order?: 'asc' | 'desc';
+}
+
+/**
+ * sort type
+ */
+export type TSortBy = string | ISortByItem | (string | ISortByItem)[];
+
+export function isValidSortBy(sortBy: TSortBy): boolean {
+  if (Array.isArray(sortBy)) {
+    if (sortBy.length === 0) {
+      return false;
+    }
+
+    // validate each array item
+    return sortBy.every((sortByItem) => isValidSortBy(sortByItem));
+  }
+
+  if (typeof sortBy !== 'string') {
+    return isValidSortByItem(sortBy);
+  }
+
+  if (sortBy.length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * @internal
+ */
+function isValidSortByItem({ property, order }: ISortByItem): boolean {
+
+  if (typeof property !== 'string') {
+    return false;
+  }
+
+  if (property.length === 0) {
+    return false;
+  }
+
+  // when present, verify that order is one of 'asc' or 'desc'
+  if (order && order !== 'asc' && order !== 'desc') {
+    return false;
+  }
+
+  return true;
+}
+
+export function stringifySortBy(sortBy: TSortBy): string {
+  if (!isValidSortBy(sortBy)) {
+    throw new Error('invalid sortby');
+  }
+
+  if (Array.isArray(sortBy)) {
+    return sortBy
+      .map((sortByItem) => {
+        if (typeof sortByItem !== 'string') {
+          return stringifySortByItem(sortByItem);
+        }
+
+        return sortByItem;
+      }).toString();
+  }
+
+  if (typeof sortBy !== 'string') {
+    return stringifySortByItem(sortBy);
+  }
+
+  return sortBy;
+}
+
+/**
+ * @internal
+ */
+function stringifySortByItem({ property, order }: ISortByItem): string {
+  return `${order === 'desc' ? '-' : ''}${property}`;
+}

--- a/packages/features/test/unit/sortby.ts
+++ b/packages/features/test/unit/sortby.ts
@@ -1,0 +1,63 @@
+import { isValidSortBy, stringifySortBy } from '../../src/sortby';
+
+test('isValidSortBy() should return true for valid input', () => {
+  expect(isValidSortBy('PROPERTY_A')).toBe(true);
+  expect(isValidSortBy(['PROPERTY_A', '-PROPERTY_B'])).toBe(true);
+  expect(isValidSortBy({ property: 'PROPERTY_A' })).toBe(true);
+  expect(isValidSortBy({ property: 'PROPERTY_A', order: 'asc' })).toBe(true);
+  expect(isValidSortBy({ property: 'PROPERTY_A', order: 'desc' })).toBe(true);
+  expect(isValidSortBy([
+    { property: 'PROPERTY_A', order: 'asc' },
+    { property: 'PROPERTY_B', order: 'desc' },
+  ])).toBe(true);
+  expect(isValidSortBy([
+    'PROPERTY_A',
+    { property: 'PROPERTY_B', order: 'desc' },
+  ])).toBe(true);
+});
+
+test('isValidSortBy() should return false for invalid input', () => {
+  expect(isValidSortBy('')).toBe(false);
+  expect(isValidSortBy([])).toBe(false);
+  expect(isValidSortBy([''])).toBe(false);
+  expect(isValidSortBy({} as any)).toBe(false);
+  expect(isValidSortBy([{} as any])).toBe(false);
+  expect(isValidSortBy({ property: '' })).toBe(false);
+  expect(isValidSortBy([{ property: '' } as any])).toBe(false);
+  expect(isValidSortBy({ property: 'PROPERTY_A', order: 'random' } as any)).toBe(false);
+  expect(isValidSortBy([{ property: 'PROPERTY_B', order: 'random' } as any])).toBe(false);
+});
+
+test('stringifySortBy() should return the passed string for string input', () => {
+  expect(stringifySortBy('PROPERTY_A')).toBe('PROPERTY_A');
+});
+
+test('stringifySortBy() should return a comma seperated sortby string for string array input', () => {
+  expect(stringifySortBy(['PROPERTY_A', '-PROPERTY_B'])).toBe('PROPERTY_A,-PROPERTY_B');
+});
+
+test('stringifySortBy() should return ascending sortby string', () => {
+  expect(stringifySortBy('PROPERTY_A')).toBe('PROPERTY_A');
+  expect(stringifySortBy({ property: 'PROPERTY_A' })).toBe('PROPERTY_A');
+  expect(stringifySortBy([{ property: 'PROPERTY_A' }])).toBe('PROPERTY_A');
+  expect(stringifySortBy({ property: 'PROPERTY_A', order: 'asc' })).toBe('PROPERTY_A');
+  expect(stringifySortBy([{ property: 'PROPERTY_A', order: 'asc' }])).toBe('PROPERTY_A');
+});
+
+test('stringifySortBy() should return descending sortby string', () => {
+  expect(stringifySortBy('-PROPERTY_A')).toBe('-PROPERTY_A');
+  expect(stringifySortBy({ property: 'PROPERTY_A', order: 'desc' })).toBe('-PROPERTY_A');
+  expect(stringifySortBy([{ property: 'PROPERTY_A', order: 'desc' }])).toBe('-PROPERTY_A');
+});
+
+test('stringifySortBy() should return multi property sortby string', () => {
+  expect(stringifySortBy('PROPERTY_A,-PROPERTY_B')).toBe('PROPERTY_A,-PROPERTY_B');
+  expect(stringifySortBy([
+    'PROPERTY_A',
+    { property: 'PROPERTY_B', order: 'desc' }
+  ])).toBe('PROPERTY_A,-PROPERTY_B');
+  expect(stringifySortBy([
+    { property: 'PROPERTY_A' },
+    { property: 'PROPERTY_B', order: 'desc' }
+  ])).toBe('PROPERTY_A,-PROPERTY_B');
+});


### PR DESCRIPTION
This PR adds support for the sortby query parameter as specified in #15 (comment).

This allows users to control in which sorting order requested features should be returned.