### PR TITLE
Add support for the `feature-filter` query parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *.log
 .DS_Store
+.npmrc
 node_modules
 dist
 lerna-debug.log
 npm-debug.log
 doc
+coverage

--- a/packages/features/CHANGELOG.md
+++ b/packages/features/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 * Support to the `properties` query parameter ([#16](https://github.com/haoliangyu/ogcapi-js/pull/16))
 * Support to the `sortby` query parameter ([#17](https://github.com/haoliangyu/ogcapi-js/pull/17))
+* Support to the `filter` query parameters ([#18](https://github.com/haoliangyu/ogcapi-js/pull/17))
 
 ## 0.2.3 - 2021-03-17
 

--- a/packages/features/README.md
+++ b/packages/features/README.md
@@ -7,6 +7,7 @@ A lightweight JavaScript client library for [OGCAPI - Features](https://github.c
 This library works with endpoints defined at:
 * [OGC API - Features - Part 1: Core](http://docs.opengeospatial.org/DRAFTS/17-069r2.html)
 * [OGC API - Features - Part 2: Coordinate Reference Systems by Reference](http://docs.opengeospatial.org/is/18-058/18-058.html)
+* [OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)](http://docs.opengeospatial.org/is/18-058/18-058.html)
 
 See more details at the [documentation](https://haoliangyu.github.io/ogcapi-js).
 

--- a/packages/features/src/filter/crs.ts
+++ b/packages/features/src/filter/crs.ts
@@ -1,0 +1,5 @@
+import { isUrl } from "../util";
+
+export function isValidFilterCrs(filterCrs: string): boolean {
+  return isUrl(filterCrs);
+}

--- a/packages/features/src/filter/index.ts
+++ b/packages/features/src/filter/index.ts
@@ -1,0 +1,113 @@
+import { isObject } from '../util';
+import { isValidFilterCrs } from './crs';
+import { EFilterLang, guessFilterLang, isValidFilterLang } from './lang';
+
+// re-export types and constants
+export { EFilterLang } from './lang';
+
+/**
+ * @internal
+ */
+interface IStringifyFilterOptions {
+  filter: TFilter;
+  filterLang?: EFilterLang;
+  filterCrs?: string;
+}
+
+/**
+ * @internal
+ */
+interface IStringifyFilterResult {
+  filter: string;
+  filterLang: string;
+  filterCrs?: string;
+}
+
+/**
+ * cql text filter
+ */
+export type TTextFilter = string;
+
+/**
+ * cql json filter
+ */
+export interface IJSONFilter {
+  [record: string]: any;
+}
+
+/**
+ * filter type
+ */
+export type TFilter = TTextFilter | IJSONFilter;
+
+/**
+ * @internal
+ */
+function isValidTextFilter(filter: TFilter): boolean {
+  if (typeof filter !== 'string') {
+    return false;
+  }
+
+  if (filter.length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * @internal
+ */
+function isValidJSONFilter(filter: TFilter): boolean {
+  if (!isObject(filter)) {
+    return false;
+  }
+
+  if (Object.keys(filter).length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isValidFilter(filter: TFilter): boolean {
+  if (!isValidTextFilter(filter) && !isValidJSONFilter(filter)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function stringifyFilter({
+  filter,
+  filterCrs,
+  filterLang,
+}: IStringifyFilterOptions): IStringifyFilterResult {
+  if (!isValidFilter(filter)) {
+    throw new Error('invalid filter');
+  }
+
+  if (filterCrs && !isValidFilterCrs(filterCrs)) {
+    throw new Error('invalid filter crs');
+  }
+
+  if (filterLang && !isValidFilterLang(filterLang)) {
+    throw new Error('invalid filter lang');
+  }
+
+  // try to guess filter lang when not available
+  if (!filterLang) {
+    filterLang = guessFilterLang(filter);
+  }
+
+  // strinigfy when filter is an object
+  if (typeof filter !== 'string') {
+    filter = JSON.stringify(filter);
+  }
+
+  return {
+    filter,
+    filterCrs,
+    filterLang,
+  };
+}

--- a/packages/features/src/filter/lang.ts
+++ b/packages/features/src/filter/lang.ts
@@ -1,0 +1,29 @@
+import { isObject } from "../util";
+
+/**
+ * filter lang enumeration
+ */
+export enum EFilterLang {
+  TEXT = 'cql-text',
+  JSON = 'cql-json',
+}
+
+export function isValidFilterLang(filterLang: EFilterLang) {
+  if (filterLang !== EFilterLang.TEXT && filterLang !== EFilterLang.JSON) {
+    return false;
+  }
+
+  return true;
+}
+
+export function guessFilterLang(filter: any): EFilterLang {
+  if (typeof filter === 'string') {
+    return EFilterLang.TEXT;
+  }
+
+  if (isObject(filter)) {
+    return EFilterLang.JSON;
+  }
+
+  throw new Error('failed to guess filter lang from filter');
+}

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -10,7 +10,7 @@ import { stringifyFilter, TFilter, EFilterLang } from './filter';
 export { IDateRange } from './datetime';
 export { TSortBy, ISortByItem } from './sortby';
 export {
-  EFilterLang,
+  EFilterLang as FilterLang,
   TFilter,
   TTextFilter,
   IJSONFilter,

--- a/packages/features/src/util.ts
+++ b/packages/features/src/util.ts
@@ -1,0 +1,14 @@
+export function isObject(target: any): boolean {
+  return !!target && target.constructor === Object;
+}
+
+export function isUrl(target: any): boolean {
+  // use new URL() to test if target a valid URI reference
+  try {
+    new URL(target);
+  } catch {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/features/test/unit/filter/crs.test.ts
+++ b/packages/features/test/unit/filter/crs.test.ts
@@ -1,0 +1,9 @@
+import { isValidFilterCrs } from "../../../src/filter/crs";
+
+test('isValidFilterCrs() should return true for valid input', () => {
+  expect(isValidFilterCrs('http://www.opengis.net/def/crs/OGC/1.3/CRS84')).toBe(true);
+});
+
+test('isValidFilterCrs() should return false for invalid input', () => {
+  expect(isValidFilterCrs('CRS84')).toBe(false);
+});

--- a/packages/features/test/unit/filter/index.test.ts
+++ b/packages/features/test/unit/filter/index.test.ts
@@ -1,0 +1,57 @@
+import { isValidFilter, stringifyFilter, EFilterLang } from '../../../src/filter/index';
+
+test('isValidFilter() should return true for valid input', () => {
+  expect(isValidFilter('PROPERTY_A = 3')).toBe(true);
+  expect(isValidFilter({ and: [] })).toBe(true);
+});
+
+test('isValidFilter() should return false for invalid input', () => {
+  expect(isValidFilter('')).toBe(false);
+  expect(isValidFilter({})).toBe(false);
+  expect(isValidFilter(1 as any)).toBe(false);
+  expect(isValidFilter([] as any)).toBe(false);
+  expect(isValidFilter(true as any)).toBe(false);
+});
+
+test('stringifyFilter() should return the passed string for string input', () => {
+  expect(stringifyFilter({ filter: 'PROPERTY_A = 3' }).filter).toBe('PROPERTY_A = 3');
+});
+
+test('stringifyFilter() should return the stringified json for object input', () => {
+  expect(stringifyFilter({ filter: { and: [] } }).filter).toBe('{"and":[]}');
+});
+
+test("stringifyFilter() should auto guess filter lang", () => {
+  expect(stringifyFilter({ filter: 'PROPERTY_A = 3' }).filterLang).toBe(EFilterLang.TEXT);
+  expect(stringifyFilter({ filter: { and: [] } }).filterLang).toBe(EFilterLang.JSON);
+});
+
+test("stringifyFilter() should return the passed uri for filter crs", () => {
+  expect(stringifyFilter({
+    filter: 'PROPERTY_A = 3',
+    filterCrs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+  }).filterCrs).toBe('http://www.opengis.net/def/crs/OGC/1.3/CRS84');
+});
+
+
+test('stringifyFilter() should throw an error for invalid filter', () => {
+  expect(() => stringifyFilter({ filter: '' })).toThrow('invalid filter');
+  expect(() => stringifyFilter({ filter: {} })).toThrow('invalid filter');
+  expect(() => stringifyFilter({ filter: 1 as any })).toThrow('invalid filter');
+  expect(() => stringifyFilter({ filter: [] as any })).toThrow('invalid filter');
+  expect(() => stringifyFilter({ filter: true as any })).toThrow('invalid filter');
+});
+
+test('stringifyFilter() should throw an error for invalid filter lang', () => {
+  expect(() => stringifyFilter({
+    filter: 'PROPERTY_A = 3',
+    filterLang: 'cql-xml' as any,
+  })).toThrow('invalid filter lang');
+});
+
+test('stringifyFilter() should throw an error for invalid filter crs', () => {
+  expect(() => stringifyFilter({
+    filter: 'PROPERTY_A = 3',
+    filterCrs: 'CRS84',
+  })).toThrow('invalid filter crs');
+});

--- a/packages/features/test/unit/filter/lang.test.ts
+++ b/packages/features/test/unit/filter/lang.test.ts
@@ -1,0 +1,24 @@
+import { isValidFilterLang, EFilterLang, guessFilterLang } from '../../../src/filter/lang';
+
+test('isValidFilterLang() should return true for valid input', () => {
+  expect(isValidFilterLang(EFilterLang.TEXT)).toBe(true);
+  expect(isValidFilterLang(EFilterLang.JSON)).toBe(true);
+});
+
+test('isValidFilterLang() should return false for invalid input', () => {
+  expect(isValidFilterLang('cql-xml' as any)).toBe(false);
+});
+
+test("guessFilterLang() should return 'cql-text' for string input", () => {
+  expect(guessFilterLang('')).toBe(EFilterLang.TEXT);
+});
+
+test("guessFilterLang() should return 'cql-json' for object input", () => {
+  expect(guessFilterLang({ and: [] })).toBe(EFilterLang.JSON);
+});
+
+test("guessFilterLang() should throw for non string input and non object input", () => {
+  expect(() => guessFilterLang([])).toThrow('failed to guess filter lang from filter');
+  expect(() => guessFilterLang(3)).toThrow('failed to guess filter lang from filter');
+  expect(() => guessFilterLang(true)).toThrow('failed to guess filter lang from filter');
+});

--- a/packages/features/test/unit/util.test.ts
+++ b/packages/features/test/unit/util.test.ts
@@ -1,0 +1,24 @@
+import { isObject, isUrl } from "../../src/util";
+
+test('isObject() should return true for object input', () => {
+  expect(isObject({})).toBe(true);
+});
+
+test('isObject() should return false for non object input', () => {
+  expect(isObject('')).toBe(false);
+  expect(isObject(3)).toBe(false);
+  expect(isObject([])).toBe(false);
+  expect(isObject(function() {})).toBe(false);
+});
+
+test('isUrl() should return true for url input', () => {
+  expect(isUrl('http://localhost/')).toBe(true);
+  expect(isUrl(new URL('http://localhost/'))).toBe(true);
+});
+
+test('isUrl() should return false for non url input', () => {
+  expect(isUrl('')).toBe(false);
+  expect(isUrl(3)).toBe(false);
+  expect(isUrl([])).toBe(false);
+  expect(isUrl({})).toBe(false);
+});


### PR DESCRIPTION
This PR adds support for the `feature-filter` query parameter as specified in #15.

This allows users by using CQL expressions to filter the requested features by attributes and spatial conditions.

@haoliangyu

FYI:

I have noticed, that

 - the `sortby` query parameter is applied to the query string as `sortBy`.
 - one test case is missing for `sortby`.
 - the `e2e` integration tests are missing for the new query parameters.

I will provide a different PR for those things later.