### PR TITLE
Part 3 cleanup and fixes

### DIFF
--- a/packages/features/src/bbox.ts
+++ b/packages/features/src/bbox.ts
@@ -1,3 +1,5 @@
+import { isValidCrs } from "./crs";
+
 export function isValidBbox(bbox: number[]): boolean {
   if (!Array.isArray(bbox)) {
     return false;
@@ -17,4 +19,12 @@ export function stringifyBbox(bbox: number[]): string {
   }
 
   return bbox.toString();
+}
+
+export function stringifyBboxCrs(bboxCrs: string): string {
+  if (!isValidCrs(bboxCrs)) {
+    throw new Error('invalid bbox crs');
+  }
+
+  return bboxCrs;
 }

--- a/packages/features/src/crs.ts
+++ b/packages/features/src/crs.ts
@@ -1,0 +1,13 @@
+import { isUrl } from "./util";
+
+export function isValidCrs(crs: string): boolean {
+  return isUrl(crs);
+}
+
+export function stringifyCrs(crs: string): string {
+  if (!isUrl(crs)) {
+    throw new Error('invalid crs');
+  }
+
+  return crs;
+}

--- a/packages/features/src/filter/crs.ts
+++ b/packages/features/src/filter/crs.ts
@@ -1,5 +1,0 @@
-import { isUrl } from "../util";
-
-export function isValidFilterCrs(filterCrs: string): boolean {
-  return isUrl(filterCrs);
-}

--- a/packages/features/src/filter/index.ts
+++ b/packages/features/src/filter/index.ts
@@ -1,5 +1,5 @@
 import { isObject } from '../util';
-import { isValidFilterCrs } from './crs';
+import { isValidCrs } from '../crs';
 import { EFilterLang, guessFilterLang, isValidFilterLang } from './lang';
 
 // re-export types and constants
@@ -87,7 +87,7 @@ export function stringifyFilter({
     throw new Error('invalid filter');
   }
 
-  if (filterCrs && !isValidFilterCrs(filterCrs)) {
+  if (filterCrs && !isValidCrs(filterCrs)) {
     throw new Error('invalid filter crs');
   }
 

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -105,7 +105,7 @@ export class Service {
     }
 
     if (options.sortby) {
-      requestParams.sortBy = stringifySortBy(options.sortby);
+      requestParams.sortby = stringifySortBy(options.sortby);
     }
 
     if (options.filter) {

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -92,7 +92,7 @@ export class Service {
       requestParams.bbox = stringifyBbox(options.bbox);
 
       if (options.bboxCrs) {
-        requestParams['bbox_crs'] = options.bboxCrs;
+        requestParams['bbox-crs'] = options.bboxCrs;
       }
     }
 

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -1,10 +1,11 @@
-import { stringifyBbox } from './bbox';
+import { stringifyBbox, stringifyBboxCrs } from './bbox';
 import { stringifyDatetime, IDateRange } from './datetime';
 import { stringifyProperties } from './properties';
 import { stringifySortBy, TSortBy } from './sortby';
 import request, { IRequestParams } from './request';
 import { FeatureCollection, Feature } from 'geojson';
 import { stringifyFilter, TFilter, EFilterLang } from './filter';
+import { stringifyCrs } from './crs';
 
 // re-export constants, interfaces and types for better user compatibility
 export { IDateRange } from './datetime';
@@ -92,7 +93,7 @@ export class Service {
       requestParams.bbox = stringifyBbox(options.bbox);
 
       if (options.bboxCrs) {
-        requestParams['bbox-crs'] = options.bboxCrs;
+        requestParams['bbox-crs'] = stringifyBboxCrs(options.bboxCrs);
       }
     }
 
@@ -148,7 +149,7 @@ export class Service {
     const requestParams: IRequestParams = Object.assign({}, options.params);
 
     if (options.crs) {
-      requestParams.crs = options.crs;
+      requestParams.crs = stringifyCrs(options.crs);
     }
 
     const result: IFeature = await request(url, requestParams);

--- a/packages/features/test/mock-request.ts
+++ b/packages/features/test/mock-request.ts
@@ -1,11 +1,12 @@
 import fetchMock from 'fetch-mock';
 
-export default function mockRequest(url: string, response: any): any {
+export default function mockRequest(url: string, response: any, options: any = {}): any {
   fetchMock.mock(
     {
       url,
       method: 'GET',
       overwriteRoutes: true,
+      ...options,
     },
     response
   );

--- a/packages/features/test/unit/bbox.test.ts
+++ b/packages/features/test/unit/bbox.test.ts
@@ -1,4 +1,4 @@
-import { isValidBbox, stringifyBbox } from '../../src/bbox';
+import { isValidBbox, stringifyBbox, stringifyBboxCrs } from '../../src/bbox';
 
 test('isValidBbox() should return false for invalid input', () => {
   expect(isValidBbox([])).toBe(false);
@@ -16,4 +16,14 @@ test('stringifyBbox() should throw an error for invalid input', () => {
 
 test('stringifyBbox() should return a commas-separated number array', () => {
   expect(stringifyBbox([1, 2, 3, 4])).toBe('1,2,3,4');
+});
+
+test('stringifyBbboxCrs() should throw an error for invalid input', () => {
+  expect(() => stringifyBboxCrs('CRS84')).toThrow('invalid bbox crs');
+});
+
+test('stringifyBbboxCrs() should return passed crs', () => {
+  expect(stringifyBboxCrs('http://www.opengis.net/def/crs/OGC/1.3/CRS84')).toBe(
+    'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+  );
 });

--- a/packages/features/test/unit/crs.test.ts
+++ b/packages/features/test/unit/crs.test.ts
@@ -1,0 +1,20 @@
+import { isValidCrs, stringifyCrs } from "../../src/crs";
+
+test('isValidCrs() should return true for valid input', () => {
+  expect(isValidCrs('http://www.opengis.net/def/crs/OGC/1.3/CRS84')).toBe(true);
+});
+
+test('isValidCrs() should return false for invalid input', () => {
+  expect(isValidCrs('CRS84')).toBe(false);
+});
+
+test('stringifyCrs() should throw an error for invalid input', () => {
+  expect(() => stringifyCrs('CRS84')).toThrow('invalid crs');
+});
+
+
+test('stringifyCrs() should return passed crs', () => {
+  expect(stringifyCrs('http://www.opengis.net/def/crs/OGC/1.3/CRS84')).toBe(
+    'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+  );
+});

--- a/packages/features/test/unit/filter/crs.test.ts
+++ b/packages/features/test/unit/filter/crs.test.ts
@@ -1,9 +1,0 @@
-import { isValidFilterCrs } from "../../../src/filter/crs";
-
-test('isValidFilterCrs() should return true for valid input', () => {
-  expect(isValidFilterCrs('http://www.opengis.net/def/crs/OGC/1.3/CRS84')).toBe(true);
-});
-
-test('isValidFilterCrs() should return false for invalid input', () => {
-  expect(isValidFilterCrs('CRS84')).toBe(false);
-});

--- a/packages/features/test/unit/index.test.ts
+++ b/packages/features/test/unit/index.test.ts
@@ -39,25 +39,25 @@ test('getCollection() should return a collection', async function() {
 });
 
 test('getFeatures() should fetch features with parameters', async function() {
-  const searchParams = new URLSearchParams();
-
-  // order is important and must match processing in service.getFeatures().
-  searchParams.set('f', 'json');
-  searchParams.set('bbox', '1,2,3,4');
-  searchParams.set('bbox-crs', 'http://www.opengis.net/def/crs/OGC/1.3/CRS84');
-  searchParams.set('datetime', '2021-12-21T00:00:00.000Z');
-  searchParams.set('properties', 'PROPERTY_A,PROPERTY_B');
-  searchParams.set('sortby', 'PROPERTY_A,-PROPERTY_B');
-  searchParams.set('filter', 'PROPERTY_A = 3');
-  searchParams.set('filter-lang', 'cql-text')
-  searchParams.set('filter-crs', 'http://www.opengis.net/def/crs/OGC/1.3/CRS84');
-  searchParams.set('limit', '1');
-
   mockRequest(
-    `https://service.com/collections/test/items?${searchParams.toString()}`,
+    `https://service.com/collections/test/items`,
     {
       type: 'FeatureCollection',
       features: [],
+    },
+    {
+      query:  {
+        f: "json",
+        limit: "1",
+        bbox: "1,2,3,4",
+        "bbox-crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+        datetime: "2021-12-21T00:00:00.000Z",
+        properties: "PROPERTY_A,PROPERTY_B",
+        sortby: "PROPERTY_A,-PROPERTY_B",
+        filter: "PROPERTY_A = 3",
+        "filter-lang": "cql-text",
+        "filter-crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+      },
     }
   );
 

--- a/packages/features/test/unit/index.test.ts
+++ b/packages/features/test/unit/index.test.ts
@@ -1,4 +1,4 @@
-import { Service } from '../../src/index';
+import { Service, FilterLang } from '../../src/index';
 import mockRequest from '../mock-request';
 
 test('getConformance() should return a list of conformances', async function() {
@@ -39,8 +39,22 @@ test('getCollection() should return a collection', async function() {
 });
 
 test('getFeatures() should fetch features with parameters', async function() {
+  const searchParams = new URLSearchParams();
+
+  // order is important and must match processing in service.getFeatures().
+  searchParams.set('f', 'json');
+  searchParams.set('bbox', '1,2,3,4');
+  searchParams.set('bbox-crs', 'http://www.opengis.net/def/crs/OGC/1.3/CRS84');
+  searchParams.set('datetime', '2021-12-21T00:00:00.000Z');
+  searchParams.set('properties', 'PROPERTY_A,PROPERTY_B');
+  searchParams.set('sortby', 'PROPERTY_A,-PROPERTY_B');
+  searchParams.set('filter', 'PROPERTY_A = 3');
+  searchParams.set('filter-lang', 'cql-text')
+  searchParams.set('filter-crs', 'http://www.opengis.net/def/crs/OGC/1.3/CRS84');
+  searchParams.set('limit', '1');
+
   mockRequest(
-    'https://service.com/collections/test/items?f=json&bbox=1%2C2%2C3%2C4&bbox_crs=test&limit=1',
+    `https://service.com/collections/test/items?${searchParams.toString()}`,
     {
       type: 'FeatureCollection',
       features: [],
@@ -52,15 +66,20 @@ test('getFeatures() should fetch features with parameters', async function() {
   });
   const result = await service.getFeatures('test', {
     bbox: [1, 2, 3, 4],
-    bboxCrs: 'test',
+    bboxCrs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
     limit: 1,
+    datetime: new Date('2021-12-21T00:00:00.000Z'),
+    properties: ['PROPERTY_A', 'PROPERTY_B'],
+    sortby: ['PROPERTY_A', '-PROPERTY_B'],
+    filter: 'PROPERTY_A = 3',
+    filterLang: FilterLang.TEXT,
+    filterCrs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
   });
   expect(result).toEqual({
     type: 'FeatureCollection',
     features: [],
   });
 });
-
 test('getFeature() should fetch a feature', async function() {
   mockRequest('https://service.com/collections/test/items/a?f=json', {
     type: 'Feature',

--- a/packages/features/test/unit/index.test.ts
+++ b/packages/features/test/unit/index.test.ts
@@ -97,16 +97,25 @@ test('getFeature() should fetch a feature', async function() {
 });
 
 test('getFeature() should fetch a feature with parameters', async function () {
-  mockRequest('https://service.com/collections/test/items/a?f=json&crs=test', {
-    type: 'Feature',
-    geometry: {},
-  });
+  mockRequest(
+    'https://service.com/collections/test/items/a',
+    {
+      type: 'Feature',
+      geometry: {},
+    },
+    {
+      query: {
+        f: 'json',
+        crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+      }
+    }
+  );
 
   const service = new Service({
     baseUrl: 'https://service.com',
   });
   const result = await service.getFeature('test', 'a', {
-    crs: 'test'
+    crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
   });
   expect(result).toEqual({
     type: 'Feature',
@@ -115,16 +124,25 @@ test('getFeature() should fetch a feature with parameters', async function () {
 });
 
 test('it could use a relative path for a local service', async function () {
-  mockRequest('/my-service/collections/test/items/a?f=json&crs=test', {
-    type: 'Feature',
-    geometry: {},
-  });
+  mockRequest(
+    '/my-service/collections/test/items/a',
+    {
+      type: 'Feature',
+      geometry: {},
+    },
+    {
+      query: {
+        f: 'json',
+        crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+      }
+    }
+  );
 
   const service = new Service({
     baseUrl: '/my-service',
   });
   const result = await service.getFeature('test', 'a', {
-    crs: 'test'
+    crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
   });
   expect(result).toEqual({
     type: 'Feature',

--- a/packages/features/test/unit/index.test.ts
+++ b/packages/features/test/unit/index.test.ts
@@ -40,7 +40,7 @@ test('getCollection() should return a collection', async function() {
 
 test('getFeatures() should fetch features with parameters', async function() {
   mockRequest(
-    `https://service.com/collections/test/items`,
+    'https://service.com/collections/test/items',
     {
       type: 'FeatureCollection',
       features: [],

--- a/packages/features/test/unit/sortby.test.ts
+++ b/packages/features/test/unit/sortby.test.ts
@@ -28,6 +28,10 @@ test('isValidSortBy() should return false for invalid input', () => {
   expect(isValidSortBy([{ property: 'PROPERTY_B', order: 'random' } as any])).toBe(false);
 });
 
+test('stringifySortBy() should throw an error for invalid filters', () => {
+  expect(() => stringifySortBy({ property: '' })).toThrow('invalid sortby');
+});
+
 test('stringifySortBy() should return the passed string for string input', () => {
   expect(stringifySortBy('PROPERTY_A')).toBe('PROPERTY_A');
 });


### PR DESCRIPTION
This PR contains fixes for things I discovered or missed during developing part 3 features:

 - Rename the sorting query parameter to `sortby`. It was previously applied to the query string as `sortBy`.
 - Add missing test case for sortby.
 - Improve test for `Service#getFeatures()`
 - Rename the bbox crs query parameter to `bbox-crs`. It was previously applied to the query string as `bbox_crs`, but should be applied as `bbox-crs` according to the spec.
 
@haoliangyu Let me know, if I missed something.

I have also noticed that there is currently some inconsistency between how the query parameters `crs`, `bbox-crs` and `filter-crs` are are validated:

In `Service#getFeatures()` the `bbox-crs` is applied directly without check. This also applies to the `crs` parameter for `Service#getFeature()`. However `filter-crs` in `Service#getFeatures()` is applied with an explicit check if its value is a valid URI reference.

I would probably switch `crs` and `bbox-crs` to URI validation, since a valid URI is required for those parameters by the spec. Your thoughts on this?