### PR TITLE
Update filter-lang handling

### DIFF
--- a/packages/features/src/filter/lang.ts
+++ b/packages/features/src/filter/lang.ts
@@ -4,12 +4,21 @@ import { isObject } from '../util';
  * filter lang enumeration
  */
 export enum EFilterLang {
-  TEXT = 'cql-text',
-  JSON = 'cql-json',
+  CQL2_TEXT = 'cql2-text',
+  CQL2_JSON = 'cql2-json',
+
+  // keep for backwards compability
+  CQL_TEXT = 'cql-text',
+  CQL_JSON = 'cql-json',
 }
 
 export function isValidFilterLang(filterLang: EFilterLang) {
-  if (filterLang !== EFilterLang.TEXT && filterLang !== EFilterLang.JSON) {
+  if (
+    filterLang !== EFilterLang.CQL_TEXT &&
+    filterLang !== EFilterLang.CQL_JSON &&
+    filterLang !== EFilterLang.CQL2_TEXT &&
+    filterLang !== EFilterLang.CQL2_JSON
+  ) {
     return false;
   }
 
@@ -18,11 +27,11 @@ export function isValidFilterLang(filterLang: EFilterLang) {
 
 export function guessFilterLang(filter: any): EFilterLang {
   if (typeof filter === 'string') {
-    return EFilterLang.TEXT;
+    return EFilterLang.CQL2_TEXT;
   }
 
   if (isObject(filter)) {
-    return EFilterLang.JSON;
+    return EFilterLang.CQL2_JSON;
   }
 
   throw new Error('failed to guess filter lang from filter');

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -89,6 +89,10 @@ export class Service {
   ): Promise<IGetFeaturesResponse> {
     const requestParams: IRequestParams = Object.assign({}, options.params);
 
+    if (options.crs) {
+      requestParams.crs = stringifyCrs(options.crs);
+    }
+
     if (options.bbox) {
       requestParams.bbox = stringifyBbox(options.bbox);
 
@@ -117,7 +121,10 @@ export class Service {
       });
 
       requestParams.filter = filter;
-      requestParams['filter-lang'] = filterLang;
+
+      if (filterLang) {
+        requestParams['filter-lang'] = filterLang;
+      }
 
       if (filterCrs) {
         requestParams['filter-crs'] = filterCrs;

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -89,10 +89,6 @@ export class Service {
   ): Promise<IGetFeaturesResponse> {
     const requestParams: IRequestParams = Object.assign({}, options.params);
 
-    if (options.crs) {
-      requestParams.crs = stringifyCrs(options.crs);
-    }
-
     if (options.bbox) {
       requestParams.bbox = stringifyBbox(options.bbox);
 

--- a/packages/features/test/unit/filter/index.test.ts
+++ b/packages/features/test/unit/filter/index.test.ts
@@ -29,10 +29,10 @@ test('stringifyFilter() should return the stringified json for object input', ()
 
 test('stringifyFilter() should auto guess filter lang', () => {
   expect(stringifyFilter({ filter: 'PROPERTY_A = 3' }).filterLang).toBe(
-    EFilterLang.TEXT
+    EFilterLang.CQL2_TEXT
   );
   expect(stringifyFilter({ filter: { and: [] } }).filterLang).toBe(
-    EFilterLang.JSON
+    EFilterLang.CQL2_JSON
   );
 });
 

--- a/packages/features/test/unit/filter/lang.test.ts
+++ b/packages/features/test/unit/filter/lang.test.ts
@@ -5,8 +5,10 @@ import {
 } from '../../../src/filter/lang';
 
 test('isValidFilterLang() should return true for valid input', () => {
-  expect(isValidFilterLang(EFilterLang.TEXT)).toBe(true);
-  expect(isValidFilterLang(EFilterLang.JSON)).toBe(true);
+  expect(isValidFilterLang(EFilterLang.CQL_TEXT)).toBe(true);
+  expect(isValidFilterLang(EFilterLang.CQL2_TEXT)).toBe(true);
+  expect(isValidFilterLang(EFilterLang.CQL_JSON)).toBe(true);
+  expect(isValidFilterLang(EFilterLang.CQL2_JSON)).toBe(true);
 });
 
 test('isValidFilterLang() should return false for invalid input', () => {
@@ -14,11 +16,11 @@ test('isValidFilterLang() should return false for invalid input', () => {
 });
 
 test("guessFilterLang() should return 'cql-text' for string input", () => {
-  expect(guessFilterLang('')).toBe(EFilterLang.TEXT);
+  expect(guessFilterLang('')).toBe(EFilterLang.CQL2_TEXT);
 });
 
 test("guessFilterLang() should return 'cql-json' for object input", () => {
-  expect(guessFilterLang({ and: [] })).toBe(EFilterLang.JSON);
+  expect(guessFilterLang({ and: [] })).toBe(EFilterLang.CQL2_JSON);
 });
 
 test('guessFilterLang() should throw for non string input and non object input', () => {

--- a/packages/features/test/unit/index.test.ts
+++ b/packages/features/test/unit/index.test.ts
@@ -55,7 +55,7 @@ test('getFeatures() should fetch features with parameters', async function() {
         properties: 'PROPERTY_A,PROPERTY_B',
         sortby: 'PROPERTY_A,-PROPERTY_B',
         filter: 'PROPERTY_A = 3',
-        'filter-lang': 'cql-text',
+        'filter-lang': 'cql2-text',
         'filter-crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
       },
     }
@@ -72,7 +72,7 @@ test('getFeatures() should fetch features with parameters', async function() {
     properties: ['PROPERTY_A', 'PROPERTY_B'],
     sortby: ['PROPERTY_A', '-PROPERTY_B'],
     filter: 'PROPERTY_A = 3',
-    filterLang: FilterLang.TEXT,
+    filterLang: FilterLang.CQL2_TEXT,
     filterCrs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
   });
   expect(result).toEqual({

--- a/packages/features/test/unit/request.test.ts
+++ b/packages/features/test/unit/request.test.ts
@@ -16,7 +16,7 @@ test('request() should throw the request error', async () => {
   try {
     await request('https://www.example.com');
     expect(true).toBe(false);
-  } catch (error) {
+  } catch (error: any) {
     expect(error.message).toBe('Internal Server Error');
   }
 });


### PR DESCRIPTION
Since some aspects of Part 3 got reworked, the current filter-lang handling is outdated. According to the [new spec](https://docs.ogc.org/DRAFTS/19-079r1.html#filter-lang-param), `filter-lang` must be either `cql2-text` or `cql2-json`.

I kept the old `filter-lang` enum values for backwards compability, since there might be some service implementations, which have not been updated according to the revised spec.