### PR TITLE
Support Requirement Class "Search" from OGC API - Features Part 5 proposal

### DIFF
--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -142,6 +142,7 @@ export class FeatureService {
       url,
       params,
       method: 'POST',
+      headers: { 'content-type': 'application/json' },
     });
     return result;
   }

--- a/packages/shared/src/request.ts
+++ b/packages/shared/src/request.ts
@@ -15,6 +15,7 @@ export async function request({
   const res: Response = await fetch(fetchUrl, {
     method,
     body,
+    headers,
   });
 
   if (!res.ok) {

--- a/packages/shared/src/request.ts
+++ b/packages/shared/src/request.ts
@@ -5,19 +5,13 @@
  */
 export async function request({
   url,
+  headers = {},
   params = {},
   method = 'GET',
 }: IRequestOptions): Promise<any> {
-  const searchParams = new URLSearchParams();
-  searchParams.append('f', 'json');
-
-  for (const key in params) {
-    searchParams.append(key, params[key].toString());
-  }
-
   const isGet = method === 'GET';
-  const fetchUrl = isGet ? `${url}?${searchParams.toString()}` : url;
-  const body = !isGet ? searchParams : undefined;
+  const fetchUrl = isGet ? `${url}?${toSearchParams(params).toString()}` : url;
+  const body = !isGet ? toBody(params, headers) : undefined;
   const res: Response = await fetch(fetchUrl, {
     method,
     body,
@@ -30,12 +24,53 @@ export async function request({
   return res.json();
 }
 
+const CONTENT_TYPE_HEADER = 'content-type';
+const APPLICATION_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded';
+const APPLICATION_JSON = 'application/json';
+
+function toBody(params: IRequestParams, headers: IRequestHeaders) {
+  const contentType = getContentType(headers).toLowerCase();
+
+  if (contentType.startsWith(APPLICATION_X_WWW_FORM_URLENCODED)) {
+    return toSearchParams(params);
+  } else if (contentType.startsWith(APPLICATION_JSON)) {
+    return toJSON(params);
+  }
+
+  return String(params);
+}
+
+function getContentType(headers: IRequestHeaders): string {
+  const contentType = Object.keys(headers)
+    .filter((header) => header.toLowerCase() === CONTENT_TYPE_HEADER)
+    .map(header => headers[header])[0];
+
+  return typeof contentType === 'string' ? contentType : APPLICATION_X_WWW_FORM_URLENCODED;
+}
+
+function toSearchParams(params: IRequestParams) {
+  const searchParams = new URLSearchParams();
+  searchParams.append('f', 'json');
+  for (const key in params) {
+    searchParams.append(key, params[key].toString());
+  }
+  return searchParams;
+}
+
+function toJSON(params: IRequestParams) {
+  return JSON.stringify(params);
+}
 export interface IRequestParams {
+  [key: string]: any;
+}
+
+export interface IRequestHeaders {
   [key: string]: any;
 }
 
 export interface IRequestOptions {
   url: string;
-  params?: IRequestParams
+  params?: IRequestParams;
+  headers?: IRequestHeaders;
   method?: 'GET' | 'POST';
 }

--- a/packages/shared/src/request.ts
+++ b/packages/shared/src/request.ts
@@ -3,10 +3,11 @@
  * @param url
  * @param params
  */
-export async function request(
-  url: string,
-  params: IRequestParams = {}
-): Promise<any> {
+export async function request({
+  url,
+  params = {},
+  method = 'GET',
+}: IRequestOptions): Promise<any> {
   const searchParams = new URLSearchParams();
   searchParams.append('f', 'json');
 
@@ -14,8 +15,12 @@ export async function request(
     searchParams.append(key, params[key].toString());
   }
 
-  const res: Response = await fetch(`${url}?${searchParams.toString()}`, {
-    method: 'GET',
+  const isGet = method === 'GET';
+  const fetchUrl = isGet ? `${url}?${searchParams.toString()}` : url;
+  const body = !isGet ? searchParams : undefined;
+  const res: Response = await fetch(fetchUrl, {
+    method,
+    body,
   });
 
   if (!res.ok) {
@@ -27,4 +32,10 @@ export async function request(
 
 export interface IRequestParams {
   [key: string]: any;
+}
+
+export interface IRequestOptions {
+  url: string;
+  params?: IRequestParams
+  method?: 'GET' | 'POST';
 }

--- a/packages/shared/test/unit/request.test.ts
+++ b/packages/shared/test/unit/request.test.ts
@@ -57,3 +57,55 @@ test('request() should accept date formatted parameter', async () => {
   });
   expect(result.success).toBe(true);
 });
+
+test('request() should forward headers ', async () => {
+  mockRequest(
+    'https://www.example.com',
+    {
+      success: true,
+    },
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        'accept-language': '*',
+      }
+    }
+  );
+
+  const result = await request({
+    url: 'https://www.example.com',
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      'accept-language': '*',
+    }
+  });
+  expect(result.success).toBe(true);
+});
+
+test('request() should send JSON when content-type header is application/json ', async () => {
+  mockRequest(
+    'https://www.example.com',
+    {
+      success: true,
+    },
+    {
+      method: 'POST',
+      body: { f: 'json' },
+      headers: {
+        'content-type': 'application/json',
+      }
+    }
+  );
+
+  const result = await request({
+    url: 'https://www.example.com',
+    method: 'POST',
+    params: { f: 'json' },
+    headers: {
+      'content-type': 'application/json',
+    }
+  });
+  expect(result.success).toBe(true);
+});

--- a/packages/shared/test/unit/request.test.ts
+++ b/packages/shared/test/unit/request.test.ts
@@ -6,7 +6,9 @@ test('request() should send a GET request with f=json', async () => {
     success: true,
   });
 
-  const result = await request('https://www.example.com');
+  const result = await request({
+    url: 'https://www.example.com',
+  });
   expect(result.success).toBe(true);
 });
 
@@ -14,7 +16,9 @@ test('request() should throw the request error', async () => {
   mockRequest('https://www.example.com?f=json', 500);
 
   try {
-    await request('https://www.example.com');
+    await request({
+      url: 'https://www.example.com',
+    });
     expect(true).toBe(false);
   } catch (error) {
     expect((error as Error).message).toBe('Internal Server Error');
@@ -26,10 +30,13 @@ test('request() should accept additional parameters', async () => {
     success: true,
   });
 
-  const result = await request('https://www.example.com', {
-    test: true,
-    num: 1,
-    content: 'test',
+  const result = await request({
+    url: 'https://www.example.com',
+    params: {
+      test: true,
+      num: 1,
+      content: 'test',
+    },
   });
   expect(result.success).toBe(true);
 });
@@ -42,8 +49,11 @@ test('request() should accept date formatted parameter', async () => {
     }
   );
 
-  const result = await request('https://www.example.com', {
-    datetime: '2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z',
+  const result = await request({
+    url: 'https://www.example.com',
+    params: {
+      datetime: '2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z',
+    },
   });
   expect(result.success).toBe(true);
 });


### PR DESCRIPTION
This PR implements support for [OGC API - Features - Part 5: Requirements Class "Search"](https://htmlpreview.github.io/?https://github.com/opengeospatial/ogcapi-features/blob/master/proposals/search/standard/20-096.html#clause-search).

For example GeoServer has an ongoing PR which will support the "Search" requirement class from part 5: https://github.com/geoserver/geoserver/pull/7040/. So it would be nice if this client SDK would support the "Search" requirement class from part 5 as well.

 