### PR TITLE
Set format parameter `f` only conditional

### DIFF
--- a/packages/shared/src/request.ts
+++ b/packages/shared/src/request.ts
@@ -47,7 +47,9 @@ function getContentType(headers: IRequestHeaders): string {
 
 function toSearchParams(params: IRequestParams) {
   const searchParams = new URLSearchParams();
-  searchParams.append('f', 'json');
+  if (!('f' in params)) {
+    searchParams.append('f', 'json');
+  }
   for (const key in params) {
     searchParams.append(key, params[key].toString());
   }

--- a/packages/shared/test/unit/request.test.ts
+++ b/packages/shared/test/unit/request.test.ts
@@ -164,3 +164,15 @@ test('request() should throw AbortError when signal is aborted', async () => {
       })
   ).rejects.toThrow(/abort/i);
 });
+
+test('request() should only append f=json when f param is not present', async () => {
+  mockRequest('https://www.example.com?f=geojson', {
+    success: true,
+  });
+
+  const result = await request({
+    url: 'https://www.example.com',
+    params: { f: 'geojson' },
+  });
+  expect(result.success).toBe(true);
+});


### PR DESCRIPTION
The format parameter `f` should only be set, when `f` was not explicit passed done to search params.